### PR TITLE
Проблема двойного вызова при первом упавшем запросе

### DIFF
--- a/__tests__/grpc-service.spec.ts
+++ b/__tests__/grpc-service.spec.ts
@@ -1,0 +1,130 @@
+import { GrpcService } from '../proto/GrpcService';
+import { Test, Test2_Nested } from '../proto/codegen/test_pb';
+
+jest.mock('grpc-web');
+
+describe('test genearted GrpcService', () => {
+  let grpcService: GrpcService;
+
+  beforeEach(() => {
+    grpcService = new GrpcService('http://test.com');
+    grpcService._client = {
+      thenableCall: jest.fn().mockResolvedValue(undefined),
+      rpcCall: jest.fn().mockResolvedValue(undefined),
+      serverStreaming: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call GetOrder successfully', async () => {
+    await grpcService.Test.TestService.GetOrder(Test.EmptyMessage);
+    expect(grpcService._client.thenableCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call GetOrder successfully and not call interceptor error', async () => {
+    const interceptor = jest.fn();
+    grpcService.interceptors.errors.push(interceptor);
+
+    await grpcService.Test.TestService.GetOrder(Test.EmptyMessage);
+    expect(grpcService._client.thenableCall).toHaveBeenCalledTimes(1);
+    expect(interceptor).not.toHaveBeenCalled();
+  });
+
+  it('should call GetOrder failure, call interceptor with success and try another one call GetOrder', async () => {
+    const spyerInterceptor = jest.fn().mockImplementation(() => {
+      grpcService.setMetadata({
+        token: '123',
+      });
+
+      return Promise.resolve('SUCCESS_INTERCEPTOR_CALL');
+    });
+
+    grpcService.interceptors.errors.push(spyerInterceptor);
+
+    const transportCall = jest.spyOn(grpcService._client, 'thenableCall');
+    transportCall.mockResolvedValue('SUCCESS_TRANSPORT_CALL').mockRejectedValueOnce('ERROR_TRANSPORT_CALL');
+
+    await grpcService.Test.TestService.GetOrder(Test.EmptyMessage);
+
+    expect(transportCall).toHaveBeenCalledTimes(2);
+    expect(spyerInterceptor).toHaveBeenCalledTimes(1);
+
+    expect(transportCall).toHaveBeenNthCalledWith(1, expect.any(String), expect.any(Function), {}, expect.any(Object));
+
+    await expect(transportCall.mock.results[0].value).rejects.toBe('ERROR_TRANSPORT_CALL');
+
+    expect(spyerInterceptor).toHaveBeenCalledWith('ERROR_TRANSPORT_CALL');
+    expect(spyerInterceptor.mock.results[0].value).resolves.toBe('SUCCESS_INTERCEPTOR_CALL');
+
+    expect(transportCall).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      expect.any(Function),
+      {
+        token: '123',
+      },
+      expect.any(Object),
+    );
+
+    await expect(transportCall.mock.results[1].value).resolves.toBe('SUCCESS_TRANSPORT_CALL');
+  });
+
+  it('should reject GetOrder call if interceptor rejected and do not call GetOrder another one', async () => {
+    const spyerInterceptor = jest.fn().mockRejectedValue('ERROR_INTERCEPTOR_CALL');
+
+    grpcService.interceptors.errors.push(spyerInterceptor);
+
+    const spyerThenableCall = jest.spyOn(grpcService._client, 'thenableCall').mockRejectedValue('ERROR_TRANSPORT_CALL');
+
+    await expect(grpcService.Test.TestService.GetOrder(Test.EmptyMessage)).rejects.toEqual('ERROR_INTERCEPTOR_CALL');
+
+    expect(spyerThenableCall).toHaveBeenCalledTimes(1);
+    expect(spyerInterceptor).toHaveBeenCalledTimes(1);
+  });
+
+  it('should try call GetOrder another one if it fails but interceptor success', async () => {
+    const spyerInterceptor = jest.fn().mockResolvedValue('SUCCESS_INTERCEPTOR_CALL');
+
+    grpcService.interceptors.errors.push(spyerInterceptor);
+
+    const spyerThenableCall = jest.spyOn(grpcService._client, 'thenableCall').mockRejectedValue('ERROR_TRANSPORT_CALL');
+
+    await expect(grpcService.Test.TestService.GetOrder(Test.EmptyMessage)).rejects.toEqual('ERROR_TRANSPORT_CALL');
+
+    expect(spyerThenableCall).toHaveBeenCalledTimes(2);
+    expect(spyerInterceptor).toHaveBeenCalledTimes(1);
+  });
+
+  // In current implementation it doesn't work
+  it('should call sequence of GetOrder independently if interceptor rejected. First call GetOrder rejected, second call GetOrder success', async () => {
+    const spyerInterceptor = jest.fn().mockRejectedValue('ERROR_INTERCEPTOR_CALL');
+
+    grpcService.interceptors.errors.push(spyerInterceptor);
+
+    const spyerThenableCall = jest.spyOn(grpcService._client, 'thenableCall').mockRejectedValue('ERROR_TRANSPORT_CALL');
+
+    await expect(grpcService.Test.TestService.GetOrder(Test.EmptyMessage)).rejects.toEqual('ERROR_INTERCEPTOR_CALL');
+
+    expect(spyerThenableCall).toHaveBeenCalledTimes(1);
+    expect(spyerInterceptor).toHaveBeenCalledTimes(1);
+
+    spyerThenableCall.mockResolvedValue('SUCCESS_TRANSPORT_CALL');
+
+    await expect(grpcService.Test.TestService.GetOrder(Test.EmptyMessage)).resolves.toEqual('SUCCESS_TRANSPORT_CALL');
+
+    expect(spyerInterceptor).toHaveBeenCalledTimes(1);
+    expect(spyerThenableCall).toHaveBeenCalledTimes(2);
+  });
+
+  it('always calls twice if interceptors empty and GetOrder fail', async () => {
+    const spyerThenableCall = jest.spyOn(grpcService._client, 'thenableCall').mockRejectedValue('ERROR_TRANSPORT_CALL');
+
+    return grpcService.Test.TestService.GetOrder(Test.EmptyMessage).catch((err) => {
+      expect(err).toBe('ERROR_TRANSPORT_CALL');
+      expect(spyerThenableCall).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/proto/GrpcService.ts
+++ b/proto/GrpcService.ts
@@ -13,7 +13,7 @@ export type GrpcServiceOptions = GrpcWebClientBaseOptions & {
 }
 
 export class GrpcService {
-  private client: GrpcWebClientBase;
+  _client: GrpcWebClientBase;
   private metadata: Metadata = {};
   private hostname: string;
   private options: GrpcServiceOptions;
@@ -24,10 +24,10 @@ export class GrpcService {
   constructor(hostname: string, options: GrpcServiceOptions = {}) {
     this.options = options;
     this.hostname = hostname;
-    this.client = new GrpcWebClientBase(this.options);
+    this._client = new GrpcWebClientBase(this.options);
   }
   private makeInterceptedUnaryCall = <Result, Params>(command: string, params: Params, methodDescriptor: MethodDescriptor<Params, Result>, options: MethodOptions = {}): Promise<Result> => {
-    const unaryCallHandler = (): Promise<Result> => this.client.thenableCall(this.hostname + command, params, this.metadata, methodDescriptor)
+    const unaryCallHandler = (): Promise<Result> => this._client.thenableCall(this.hostname + command, params, this.metadata, methodDescriptor)
     
     if (options.ignoreInterceptors) {
       return unaryCallHandler()

--- a/proto/GrpcService.ts
+++ b/proto/GrpcService.ts
@@ -44,7 +44,7 @@ export class GrpcService {
       unaryCallHandler().then(resolve).catch(e => {
         this.chainingInterceptors(this.interceptors.errors, e).then(() => {
           this.makeInterceptedUnaryCall<Result, Params>(command, params, methodDescriptor).then(resolve).catch(reject)
-        }).catch(reject)
+        }).catch(reject).finally(() => (this.interceptingPromise = undefined));
       });
     });
   }

--- a/src/jsgen.ts
+++ b/src/jsgen.ts
@@ -30,7 +30,7 @@ export type GrpcServiceOptions = GrpcWebClientBaseOptions & {
 }
 
 export class GrpcService {
-  private client: GrpcWebClientBase;
+  _client: GrpcWebClientBase;
   private metadata: Metadata = {};
   private hostname: string;
   private options: GrpcServiceOptions;
@@ -41,10 +41,10 @@ export class GrpcService {
   constructor(hostname: string, options: GrpcServiceOptions = {}) {
     this.options = options;
     this.hostname = hostname;
-    this.client = new GrpcWebClientBase(this.options);
+    this._client = new GrpcWebClientBase(this.options);
   }
   private makeInterceptedUnaryCall = <Result, Params>(command: string, params: Params, methodDescriptor: MethodDescriptor<Params, Result>, options: MethodOptions = {}): Promise<Result> => {
-    const unaryCallHandler = (): Promise<Result> => this.client.thenableCall(this.hostname + command, params, this.metadata, methodDescriptor)
+    const unaryCallHandler = (): Promise<Result> => this._client.thenableCall(this.hostname + command, params, this.metadata, methodDescriptor)
     
     if (options.ignoreInterceptors) {
       return unaryCallHandler()
@@ -104,7 +104,7 @@ export function createServiceSource(service: PackageService, packageName: string
 }
 
 function createServerStreamingFunction(packageName: string, serviceName: string, methodName: string) {
-  return `return this.client.serverStreaming(this.hostname + '/${packageName}.${serviceName}/${methodName}', params, this.metadata, methodInfo)`;
+  return `return this._client.serverStreaming(this.hostname + '/${packageName}.${serviceName}/${methodName}', params, this.metadata, methodInfo)`;
 }
 
 export function createServiceMethodSource(method: ServiceMethod, serviceName: string, packageName: string) {
@@ -125,7 +125,7 @@ export function createServiceMethodSource(method: ServiceMethod, serviceName: st
   if (method.responseStream) {
     ret.push(
       `${method.name}: (params: ${packageName}.I${method.requestType}): ClientReadableStream<${packageName}.${method.responseType}> => {`,
-      `  return this.client.serverStreaming(this.hostname + '/${packageName}.${serviceName}/${method.name}', params, this.metadata, this.${packageName}.${serviceName}.${methodDescriptorPropName})`,
+      `  return this._client.serverStreaming(this.hostname + '/${packageName}.${serviceName}/${method.name}', params, this.metadata, this.${packageName}.${serviceName}.${methodDescriptorPropName})`,
       '},');
   } else {
     ret.push(

--- a/src/jsgen.ts
+++ b/src/jsgen.ts
@@ -61,7 +61,7 @@ export class GrpcService {
       unaryCallHandler().then(resolve).catch(e => {
         this.chainingInterceptors(this.interceptors.errors, e).then(() => {
           this.makeInterceptedUnaryCall<Result, Params>(command, params, methodDescriptor).then(resolve).catch(reject)
-        }).catch(reject)
+        }).catch(reject).finally(() => (this.interceptingPromise = undefined));
       });
     });
   }


### PR DESCRIPTION
Столкнулся со следущей проблемой:
Есть возможность добавить интерсепторы на ошибки. Интерсептор всегда возвращает промис. Внутри мы можем решить как реагировать на упавший вызов, есть два варианта либо интерсептор зарезолвится либо зареджектится. То есть два кейса:

1) Метод падает, интерсептор резолвится. В таком случае он всегда будет слать их по два - [тест](https://github.com/maximusnikulin/grpc-web-service-generator/blob/80fdaac5e2cba9001964c0954c92698aa843a98b/__tests__/grpc-service.spec.ts#L88)
И например в случае защищенных урлов с протухшим токеном это ок, но у нас например кейс с посылкой смс кода, их запрашивает по два за раз. Тут переходим ко второму кейсу

2) Метод падает, интерсептор реджектится. В таком случае мы отправили запрос упали и упали с ошибкой из интерспетора - это ок. Но проблема начинается при следующем запросе, результат интерсептора закешится и новый вызов больше никогда не выполнится - [тест](https://github.com/maximusnikulin/grpc-web-service-generator/blob/80fdaac5e2cba9001964c0954c92698aa843a98b/__tests__/grpc-service.spec.ts#L102)

Добавил правку которая это фиксит, собственно об этом и pr - [коммит](https://github.com/maximusnikulin/grpc-web-service-generator/commit/5ada9f6ea925dc7bcebaa77af891c5e2f2966a50)

Есть свойство `ignoreInterceptors` но в таком случае мы вообще все интерсепторы отключаем у вызова 
